### PR TITLE
docs: fix outlook send import path in code example

### DIFF
--- a/docs/util/mail/outlook/send/index.html
+++ b/docs/util/mail/outlook/send/index.html
@@ -23,7 +23,7 @@
         <section>
             <h2>Code</h2>
             <pre class="code-block"><code>
-const sendEmail = require('jwz/mailer/outlook');
+const sendEmail = require('jwz/mailer/outlook/send');
 
 const sender = 'sender@outlook.com';
 const password = '1234'; // Please note: storing password in plain text is insecure.


### PR DESCRIPTION
## Summary

The Outlook "Send Mail" doc code example imported `jwz/mailer/outlook`, which is not an exported path. The package only exports `./mailer/outlook/send`, and the Usage and Explanation sections already reference `jwz/mailer/outlook/send`.

## Change

- Update the code example import to `require('jwz/mailer/outlook/send')` so it matches the package export and the rest of the page.

Companion to the code fix in jwz (#5).

---
_Generated by [Claude Code](https://claude.ai/code/session_01148Fa4o7J1t3jtiNVDuoT5)_